### PR TITLE
chore: update rand to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 chess = "3.2.0"
-rand = "0.10.0"
+rand = "0.10.1"
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Updates rand dependency from 0.10.0 to 0.10.1 to address Dependabot alert.

Closes #8

Generated with [Claude Code](https://claude.ai/code)