### PR TITLE
fix: re-base mate scores when storing/probing the transposition table

### DIFF
--- a/src/alpha_beta_algorithm.rs
+++ b/src/alpha_beta_algorithm.rs
@@ -85,6 +85,36 @@ enum ProbeResult {
 /// Below this depth the TT lookup/store cost outweighs the savings, so we skip it.
 const TT_MIN_DEPTH: i32 = 2;
 
+/// Scores beyond this magnitude are mate scores (see `check_terminal_position`).
+const MATE_SCORE_THRESHOLD: i32 = 9000;
+
+/// Mate scores encode distance to mate via the storing node's remaining depth,
+/// so they are only valid for the search that produced them. Re-base them to be
+/// node-relative before storing, so an entry stays correct when the same
+/// position is probed at a different remaining depth (e.g. by a later search
+/// in the same game).
+fn to_tt_score(score: i32, depth: i32) -> i32 {
+    if score > MATE_SCORE_THRESHOLD {
+        score - depth
+    } else if score < -MATE_SCORE_THRESHOLD {
+        score + depth
+    } else {
+        score
+    }
+}
+
+/// Inverse of `to_tt_score`: re-base a stored node-relative mate score to the
+/// probing node's remaining depth.
+fn from_tt_score(score: i32, depth: i32) -> i32 {
+    if score > MATE_SCORE_THRESHOLD {
+        score + depth
+    } else if score < -MATE_SCORE_THRESHOLD {
+        score - depth
+    } else {
+        score
+    }
+}
+
 impl AlgorithmTraits for AlphaBetaAlgorithm {
     fn get_best_move(&mut self, board: Board, depth: i32) -> Option<ChessMove> {
         let best_moves = self.search_root_moves(board, depth, None);
@@ -316,7 +346,7 @@ impl AlphaBetaAlgorithm {
         }
         let hash = self.transposition_table.hash_position(board);
         let (entry_depth, node_type, score, best_move) = match self.transposition_table.probe(hash) {
-            Some(entry) => (entry.depth, entry.node_type, entry.score, entry.best_move),
+            Some(entry) => (entry.depth, entry.node_type, from_tt_score(entry.score, depth), entry.best_move),
             None => return ProbeResult::Continue { hash, tt_move: None },
         };
         if entry_depth >= depth {
@@ -334,7 +364,7 @@ impl AlphaBetaAlgorithm {
         if depth < TT_MIN_DEPTH {
             return;
         }
-        self.transposition_table.store(hash, depth, node_type, score, best_move);
+        self.transposition_table.store(hash, depth, node_type, to_tt_score(score, depth), best_move);
     }
 
     /// Check if the position is terminal (game over) and return the appropriate score

--- a/src/alpha_beta_algorithm.rs
+++ b/src/alpha_beta_algorithm.rs
@@ -95,9 +95,13 @@ const MATE_SCORE_THRESHOLD: i32 = 9000;
 /// in the same game).
 fn to_tt_score(score: i32, depth: i32) -> i32 {
     if score > MATE_SCORE_THRESHOLD {
-        score - depth
+        let rebased = score - depth;
+        debug_assert!(rebased > MATE_SCORE_THRESHOLD, "search depth too large: re-based mate score no longer recognizable as a mate");
+        rebased
     } else if score < -MATE_SCORE_THRESHOLD {
-        score + depth
+        let rebased = score + depth;
+        debug_assert!(rebased < -MATE_SCORE_THRESHOLD, "search depth too large: re-based mate score no longer recognizable as a mate");
+        rebased
     } else {
         score
     }
@@ -464,5 +468,30 @@ mod root_search_tests {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tt_score_tests {
+    use super::*;
+
+    /// A mate 2 plies below a node searched with 5 plies remaining
+    /// (raw score 9999 + 3) must read back as the same mate distance when the
+    /// position is probed by a search with 7 plies remaining.
+    #[test]
+    fn mate_scores_round_trip_across_depths() {
+        let stored = to_tt_score(9999 + 3, 5);
+        assert_eq!(from_tt_score(stored, 7), 9999 + 5);
+
+        let stored = to_tt_score(-9999 - 3, 5);
+        assert_eq!(from_tt_score(stored, 7), -9999 - 5);
+    }
+
+    #[test]
+    fn non_mate_scores_are_untouched() {
+        assert_eq!(to_tt_score(150, 7), 150);
+        assert_eq!(to_tt_score(-150, 7), -150);
+        assert_eq!(from_tt_score(150, 7), 150);
+        assert_eq!(from_tt_score(-150, 7), -150);
     }
 }


### PR DESCRIPTION
## Problem
`checkmate4`/`checkmate5` were flaky — the engine would sometimes take 20+ plies to deliver a forced mate-in-8. Since the point of this project is testing genetic programming, game outcomes must be decided by the chromosomes, not by search artifacts.

## Root cause
Mate scores encode the distance to mate through the storing node's *remaining depth* (`-9999 - depth_left` / `9999 + depth_left`), so a stored mate score is only meaningful relative to the search that produced it. But the transposition table **persists across moves of a game** (one `AlphaBetaAlgorithm` per player; `probe` ignores entry age). A later search probing the same position at a different remaining depth read a mate score whose implied mate distance was wrong for its own root.

The visible symptom: the mating side saw several moves as equally-fast mates when they were not (root scores stuck at e.g. `-10001`), and the random tie-break among "equal" best moves sometimes picked a genuinely slower one — mate distance stopped shrinking and the game dragged on.

## Fix
The standard mate-score-in-TT treatment: re-base mate scores to be **node-relative** on store (`score ∓ depth`) and convert back to the probing search's depth on probe (`score ± depth`). With that, a cached mate entry is correct no matter which search or which remaining depth probes it, making the cross-move TT reuse sound. Non-mate scores are untouched (threshold ±9000, mate scores max out around ±10010).

Review follow-ups incorporated:
- `debug_assert` that a re-based mate score stays beyond the mate threshold, making the implicit max-search-depth invariant (depth < ~999) explicit and self-documenting.
- Unit tests pin the `to_tt_score`/`from_tt_score` round-trip algebra (mate 2 plies below a depth-5 node reads back correctly at depth 7) and the non-mate passthrough — deterministic microsecond tests, independent of the expensive integration tests.

## Verification
- `checkmate4`: **10/10 runs pass** (previously failed 5/5 on main)
- `checkmate5`: **10/10 runs pass**
- Full test suite: 3/3 consecutive green runs
- Depth-5 benchmark suite: byte-identical — exactly the same 10,560,054 nodes and results as main, since no mates occur within its horizon; zero performance cost

Note: with exact mate scores, the random tie-break at the root is harmless for determinism of *outcomes* — all tied moves now truly lead to mate in the same number of plies, so game length is invariant regardless of which one is picked. `checkmate6`/`checkmate8` stay `#[ignore]`d as before (depth-12+ searches are still computationally out of reach for the current search).