### PR TITLE
perf: bounded tournament worker pool, reuse TTs across a match's games

### DIFF
--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -3,6 +3,8 @@ use crate::chromosome::{init_new_chromosomes, Chromosome};
 use crate::repository::ChromosomeRepository;
 use chess::{Board, BoardStatus};
 use rand::RngExt;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Instant;
 
@@ -97,11 +99,8 @@ fn randomize_opponents(players: Vec<Chromosome>) -> Vec<(Chromosome, Chromosome)
     matches
 }
 
-fn play_chess_match(player1: Chromosome, player2: Chromosome, depth: i32) -> i32 {
+fn play_chess_match(alg1: &mut AlphaBetaAlgorithm, alg2: &mut AlphaBetaAlgorithm, player1: &Chromosome, player2: &Chromosome, depth: i32) -> i32 {
     let mut board = Board::default();
-    // Create separate algorithm instances to prevent TT contamination between chromosomes
-    let mut alg1 = AlphaBetaAlgorithm::new(); // For player1 (white)
-    let mut alg2 = AlphaBetaAlgorithm::new(); // For player2 (black)
     let mut move_count = 0;
     let max_moves = 100; // Prevent infinite games
 
@@ -137,8 +136,8 @@ fn play_chess_match(player1: Chromosome, player2: Chromosome, depth: i32) -> i32
 
         // Get move from appropriate player using their dedicated algorithm instance
         let chess_move = match board.side_to_move() {
-            chess::Color::White => alg1.get_best_move_with_chromosome(board, depth, &player1),
-            chess::Color::Black => alg2.get_best_move_with_chromosome(board, depth, &player2),
+            chess::Color::White => alg1.get_best_move_with_chromosome(board, depth, player1),
+            chess::Color::Black => alg2.get_best_move_with_chromosome(board, depth, player2),
         };
 
         match chess_move {
@@ -239,11 +238,19 @@ fn do_crossover_and_mutation(winner_genes: Vec<Chromosome>, wanted_genes_count: 
 fn run_match_task(task: MatchTask) -> MatchResult {
     println!("Running match {} (parallel)", task.match_id);
 
+    // One algorithm instance per player for the whole match. The transposition
+    // table caches scores computed with that player's chromosome values, so it
+    // must never be shared between chromosomes — but reusing it across the
+    // games of the same pairing is safe (same chromosome, same valuations) and
+    // avoids re-allocating and zeroing the tables for every game.
+    let mut alg1 = AlphaBetaAlgorithm::new(); // For player1 (white)
+    let mut alg2 = AlphaBetaAlgorithm::new(); // For player2 (black)
+
     let mut player1_wins = 0;
     let mut player2_wins = 0;
 
     for game in 1..=3 {
-        let result = play_chess_match(task.player1.clone(), task.player2.clone(), task.depth);
+        let result = play_chess_match(&mut alg1, &mut alg2, &task.player1, &task.player2, task.depth);
 
         match result {
             1 => {
@@ -297,28 +304,44 @@ fn run_match_task(task: MatchTask) -> MatchResult {
 }
 
 fn run_matches_parallel(matches: Vec<(Chromosome, Chromosome)>, depth: i32) -> Vec<Chromosome> {
-    let mut match_tasks = Vec::new();
+    let mut match_tasks = VecDeque::new();
 
     // Create match tasks
     for (match_id, (player1, player2)) in matches.into_iter().enumerate() {
         let task = MatchTask { player1, player2, depth, match_id };
-        match_tasks.push(task);
+        match_tasks.push_back(task);
     }
 
-    println!("Starting {} matches in parallel...", match_tasks.len());
+    // Bound the number of worker threads to the available cores: each running
+    // match holds two transposition tables, so unbounded threads would both
+    // oversubscribe the CPU and multiply memory usage with the player count.
+    let worker_count = thread::available_parallelism().map(|n| n.get()).unwrap_or(4).min(match_tasks.len()).max(1);
+    println!("Starting {} matches on {} worker threads...", match_tasks.len(), worker_count);
 
-    // Spawn threads for each match
+    let queue = Arc::new(Mutex::new(match_tasks));
     let mut handles = Vec::new();
-    for task in match_tasks {
-        let handle = thread::spawn(move || run_match_task(task));
+    for _ in 0..worker_count {
+        let queue = Arc::clone(&queue);
+        let handle = thread::spawn(move || {
+            let mut worker_results = Vec::new();
+            loop {
+                // Take the next match; the lock guard is dropped before the
+                // match runs so other workers are never blocked on it.
+                let task = queue.lock().unwrap().pop_front();
+                match task {
+                    Some(task) => worker_results.push(run_match_task(task)),
+                    None => return worker_results,
+                }
+            }
+        });
         handles.push(handle);
     }
 
-    // Wait for all threads to complete and collect results
+    // Wait for all workers to complete and collect results
     let mut results = Vec::new();
     for handle in handles {
         match handle.join() {
-            Ok(result) => results.push(result),
+            Ok(mut worker_results) => results.append(&mut worker_results),
             Err(e) => {
                 eprintln!("Thread panicked: {e:?}");
                 // Continue with other matches


### PR DESCRIPTION
## Summary
Fixes issues 5 and 6 from `PERFORMANCE_ISSUES.md` in one PR (they change the same two functions).

**Issue 5 — unbounded threads:** `run_matches_parallel` spawned one OS thread per match. With N matches that meant N×2 transposition tables resident at once and CPU oversubscription whenever matches exceeded cores. Matches now run on a worker pool sized to `available_parallelism()` (capped at the match count), pulling from a shared queue. The lock is only held while popping a task, never while a match runs.

**Issue 6 — per-game table churn:** `play_chess_match` created two fresh `AlphaBetaAlgorithm` instances per *game*, so each match allocated and zeroed six 1M-entry tables. The instances are now created once per *match* and reused across its up-to-three games.

## Chromosome isolation (unchanged, by design)
Each match still creates its **own fresh pair** of algorithm instances — `alg1` only ever searches with player 1's chromosome, `alg2` only with player 2's. Reuse happens exclusively across games of the **same pairing**, where every cached score was computed with the exact same piece valuations, so entries are always valid for the chromosome that reads them. Tables are never shared between chromosomes and never carried across matches. (Cross-game reuse is also score-correct for mate distances thanks to #14's node-relative mate encoding.)

## Results (16-core machine)
| n=40, depth 4, 1 tournament (3 runs each) | before | after |
|---|---|---|
| Max RSS | 965–989 MB | **772 MB, and bounded** |
| Wall time | 17.2–18.0 s | 15.2–18.9 s (unchanged within game-length RNG variance) |

The memory story is the point: before, RSS grew linearly with the match count (n=200 would need ~5 GB); after, it's capped by the core count no matter how many chromosomes play. Reusing tables also removes ~150 MB of allocation+zeroing per match, and warm tables make games 2–3 of a match start with that pairing's positions already cached.

## Testing
- `cargo test` — full suite green (12 tests)
- n=40 and n=4 tournaments A/B'd against current main, numbers above